### PR TITLE
zmq server remembers the entire scene tree and replays it to new websockets

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -58,6 +58,8 @@ For examples of interactive usage, see demo.ipynb_
 
 .. _demo.ipynb: demo.ipynb
 
+Under the Hood
+==============
 
 Starting a Server
 -----------------
@@ -104,27 +106,27 @@ All communication with the meshcat server happens over the ZMQ socket. Some comm
 |
 
 :ZMQ frames:
-    ``["set_object", "slash/separated/path", data]``
+    ``["set_object", "/slash/separated/path", data]``
 :Action:
-    Set the object at the given path (note the lack of initial "/"). ``data`` is a ``MsgPack``-encoded dictionary, described below. 
+    Set the object at the given path. ``data`` is a ``MsgPack``-encoded dictionary, described below. 
 :Response:
     "ok"
 
 |
 
 :ZMQ frames:
-    ``["set_transform", "slash/separated/path", data]``
+    ``["set_transform", "/slash/separated/path", data]``
 :Action:
-    Set the transform of the object at the given path (note the lack of an initial "/"). There does not need to be any geometry at that path yet, so ``set_transform`` and ``set_object`` can happen in any order. ``data`` is a ``MsgPack``-encoded dictionary, described below. 
+    Set the transform of the object at the given path. There does not need to be any geometry at that path yet, so ``set_transform`` and ``set_object`` can happen in any order. ``data`` is a ``MsgPack``-encoded dictionary, described below. 
 :Response:
     "ok"
 
 |
 
 :ZMQ frames:
-    ``["delete", "slash/separated/path", data]``
+    ``["delete", "/slash/separated/path", data]``
 :Action:
-    Delete the object at the given path (note the lack of an initial "/"). ``data`` is a ``MsgPack``-encoded dictionary, described below. 
+    Delete the object at the given path. ``data`` is a ``MsgPack``-encoded dictionary, described below. 
 :Response:
     "ok"
 
@@ -135,12 +137,15 @@ All communication with the meshcat server happens over the ZMQ socket. Some comm
 ::
 
     {
-        "type": "set_object",         // one of set_object, set_transform, or delete
-        "path": ["meshcat", "box1"],  // the path of the object
+        "type": "set_object",
+        "path": "/slash/separated/path",  // the path of the object
         "object": <three.js JSON>
     }
 
 The format of the ``object`` field is exactly the built-in JSON serialization format from three.js (note that we use the JSON structure, but actually use msgpack for the encoding due to its much better performance). For examples of the JSON structure, see the three.js wiki_ . 
+
+Note on redundancy
+    The ``type`` and ``path`` fields are duplicated: they are sent once in the first two ZeroMQ frames and once inside the MsgPack-encoded data. This is intentional and makes it easier for the server to handle messages without unpacking them fully. 
 
 .. _wiki: https://github.com/mrdoob/three.js/wiki/JSON-Geometry-format-4
 .. _msgpack: https://msgpack.org/index.html
@@ -151,7 +156,7 @@ The format of the ``object`` field is exactly the built-in JSON serialization fo
 
     {
         "type": "set_transform",
-        "path": ["meshcat", "box2"],
+        "path": "/slash/separated/path",
         "matrix": [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
     }
 
@@ -163,7 +168,7 @@ The format of the ``matrix`` in a ``set_transform`` command is a column-major ho
 
     {
         "type": "delete",
-        "path", ["meshcat", "box3"]
+        "path", "/slash/separated/path"
     }
 
 

--- a/Readme.rst
+++ b/Readme.rst
@@ -27,15 +27,15 @@ Using pip:
 
 ::
 
-	pip install meshcat
+    pip install meshcat
 
 From source:
 
 ::
 
-	git clone https://github.com/rdeits/meshcat-python
-	cd meshcat-python
-	python setup.py install
+    git clone https://github.com/rdeits/meshcat-python
+    cd meshcat-python
+    python setup.py install
 
 You will need the ZeroMQ libraries installed on your system:
 
@@ -43,13 +43,13 @@ Ubuntu/Debian:
 
 ::
 
-	apt-get install libzmq3
+    apt-get install libzmq3
 
 Homebrew:
 
 ::
 
-	brew install zmq
+    brew install zmq
 
 Usage
 =====
@@ -66,54 +66,107 @@ If you want to run your own meshcat server (for example, to communicate with the
 
 ::
 
-	meshcat-server
+    meshcat-server
 
 The server will choose an available ZeroMQ URL and print that URL over stdout. If you want to specify a URL, just do:
 
 ::
 
-	meshcat-server --zmq-url=<your URL>
+    meshcat-server --zmq-url=<your URL>
 
 You can also instruct the server to open a browser window with:
 
 ::
 
-	meshcat-server --open
+    meshcat-server --open
 
 Protocol
 --------
 
-A viewer message consists of a single ZeroMQ message containing a msgpack_ encoded dictionary. The format of the message is:
+All communication with the meshcat server happens over the ZMQ socket. Some commands consist of multiple ZMQ frames. 
 
+:ZMQ frames:
+    ``["url"]``
+:Action:
+    Request URL
+:Response:
+    The web URL for the server. Open this URL in your browser to see the 3D scene.
+
+|	
+
+:ZMQ frames:
+    ``["wait"]``
+:Action:
+    Wait for a browser to connect
+:Response:
+    "ok" when a brower has connected to the server. This is useful in scripts to block execution until geometry can actually be displayed.
+    
+|
+
+:ZMQ frames:
+    ``["set_object", "slash/separated/path", data]``
+:Action:
+    Set the object at the given path (note the lack of initial "/"). ``data`` is a ``MsgPack``-encoded dictionary, described below. 
+:Response:
+    "ok"
+
+|
+
+:ZMQ frames:
+    ``["set_transform", "slash/separated/path", data]``
+:Action:
+    Set the transform of the object at the given path (note the lack of an initial "/"). There does not need to be any geometry at that path yet, so ``set_transform`` and ``set_object`` can happen in any order. ``data`` is a ``MsgPack``-encoded dictionary, described below. 
+:Response:
+    "ok"
+
+|
+
+:ZMQ frames:
+    ``["delete", "slash/separated/path", data]``
+:Action:
+    Delete the object at the given path (note the lack of an initial "/"). ``data`` is a ``MsgPack``-encoded dictionary, described below. 
+:Response:
+    "ok"
+
+|
+
+``set_object`` data format
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
-	{
-		"commands": [
-			{
-				"type": "set_object",         // one of set_object, set_transform, or delete
-				"path": ["meshcat", "box1"],  // the path of the object
-				"object": <three.js JSON>
-			},
-			{
-				"type": "set_transform",
-				"path": ["meshcat", "box2"],
-				"matrix": [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
-			}, 
-			{
-				"type": "delete",
-				"path", ["meshcat", "box3"]
-			}
-		]
-	}
-
-A single message can consist of any number of commands of any type and in any order. 
+    {
+        "type": "set_object",         // one of set_object, set_transform, or delete
+        "path": ["meshcat", "box1"],  // the path of the object
+        "object": <three.js JSON>
+    }
 
 The format of the ``object`` field is exactly the built-in JSON serialization format from three.js (note that we use the JSON structure, but actually use msgpack for the encoding due to its much better performance). For examples of the JSON structure, see the three.js wiki_ . 
 
+.. _wiki: https://github.com/mrdoob/three.js/wiki/JSON-Geometry-format-4
+.. _msgpack: https://msgpack.org/index.html
+
+``set_transform`` data format
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+::
+
+    {
+        "type": "set_transform",
+        "path": ["meshcat", "box2"],
+        "matrix": [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
+    }
+
 The format of the ``matrix`` in a ``set_transform`` command is a column-major homogeneous transformation matrix. 
 
-.. _msgpack: https://msgpack.org/index.html
-.. _wiki: https://github.com/mrdoob/three.js/wiki/JSON-Geometry-format-4
+``delete`` data format
+^^^^^^^^^^^^^^^^^^^^^^
+::
+
+    {
+        "type": "delete",
+        "path", ["meshcat", "box3"]
+    }
+
+
 
 Packing Arrays
 --------------

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -77,7 +77,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vis.set_object(g.Box([0.2, 0.1, 0.1]))"
+    "vis.set_object(g.Box([0.2, 0.2, 0.2]))"
    ]
   },
   {
@@ -134,7 +134,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vis.set_object(g.Box([0.2, 0.2, 0.2]))"
+    "vis.set_object(g.Box([0.1, 0.1, 0.2]))"
    ]
   },
   {

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -68,22 +68,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "MeshCat also supports embedding a 3D view inside a Jupyter notebook cell:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "vis.jupyter_cell()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "To create a 3D object, we use the `set_object` method:"
    ]
   },
@@ -118,7 +102,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that calling `set_object` again will replace the existing Box:"
+    "MeshCat also supports embedding a 3D view inside a Jupyter notebook cell:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vis.jupyter_cell()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice how the 3D scene displayed in the Jupyter cell matches the one in the external window. The meshcat server process remembers the objects and transforms you've sent, so opening a new browser pointing to the same URL should give you the same scene. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calling `set_object` again will replace the existing Box:"
    ]
   },
   {
@@ -338,7 +345,7 @@
    "source": [
     "## Cart-Pole\n",
     "\n",
-    "Here's a simple example of visualizing a simple mechanism:"
+    "Here's a simple example of visualizing a mechanism:"
    ]
   },
   {

--- a/src/meshcat/commands.py
+++ b/src/meshcat/commands.py
@@ -50,13 +50,3 @@ class Delete:
             "type": "delete",
             "path": self.path
         }
-
-
-class ViewerMessage:
-    def __init__(self, commands):
-        self.commands = commands
-
-    def lower(self):
-        return {
-            "commands": [c.lower() for c in self.commands]
-        }

--- a/src/meshcat/commands.py
+++ b/src/meshcat/commands.py
@@ -22,7 +22,7 @@ class SetObject:
         return {
             "type": "set_object",
             "object": self.object.lower(),
-            "path": self.path
+            "path": "/" + "/".join(self.path)
         }
 
 
@@ -35,7 +35,7 @@ class SetTransform:
     def lower(self):
         return {
             "type": "set_transform",
-            "path": self.path,
+            "path": "/" + "/".join(self.path),
             "matrix": list(self.matrix.T.flatten())
         }
 
@@ -48,5 +48,5 @@ class Delete:
     def lower(self):
         return {
             "type": "delete",
-            "path": self.path
+            "path": "/" + "/".join(self.path)
         }

--- a/src/meshcat/servers/tree.py
+++ b/src/meshcat/servers/tree.py
@@ -1,0 +1,25 @@
+from __future__ import absolute_import, division, print_function
+
+from collections import defaultdict
+
+class TreeNode(defaultdict):
+    __slots__ = ["object", "transform"]
+
+    def __init__(self, *args, **kwargs):
+        super(TreeNode, self).__init__(*args, **kwargs)
+        self.object = None
+        self.transform = None
+
+SceneTree = lambda: TreeNode(SceneTree)
+
+def walk(tree):
+    yield tree
+    for v in tree.values():
+        for t in walk(v):  # could use `yield from` if we didn't need python2
+            yield t
+
+def find_node(tree, path):
+    if len(path) == 0:
+        return tree
+    else:
+        return find_node(tree[path[0]], path[1:])

--- a/src/meshcat/servers/zmqserver.py
+++ b/src/meshcat/servers/zmqserver.py
@@ -107,7 +107,7 @@ class ZMQWebSocketBridge(object):
             if len(frames) != 3:
                 self.zmq_socket.send(b"error: expected 3 frames")
                 return
-            path = frames[1].decode("utf-8").split("/")
+            path = list(filter(lambda x: len(x) > 0, frames[1].decode("utf-8").split("/")))
             data = frames[2]
             self.forward_to_websockets(frames)
             if cmd == "set_transform":

--- a/src/meshcat/tests/test_drawing.py
+++ b/src/meshcat/tests/test_drawing.py
@@ -32,6 +32,7 @@ class VisualizerTest(unittest.TestCase):
 
 class TestDrawing(VisualizerTest):
     def runTest(self):
+        self.vis.delete()
         v = self.vis["shapes"]
         v.set_transform(tf.translation_matrix([1., 0, 0]))
         v["cube"].set_object(g.Box([0.1, 0.2, 0.3]))

--- a/src/meshcat/tests/test_drawing.py
+++ b/src/meshcat/tests/test_drawing.py
@@ -23,6 +23,8 @@ class VisualizerTest(unittest.TestCase):
             self.vis.open()
             self.dummy_proc = None
 
+        self.vis.wait()
+
     def tearDown(self):
         if self.dummy_proc is not None:
             self.dummy_proc.kill()
@@ -79,6 +81,8 @@ class TestStandaloneServer(unittest.TestCase):
         else:
             # self.vis.open()
             self.dummy_proc = None
+
+        self.vis.wait()
 
     def runTest(self):
         v = self.vis["shapes"]

--- a/src/meshcat/visualizer.py
+++ b/src/meshcat/visualizer.py
@@ -64,7 +64,7 @@ class ViewerWindow:
         cmd_data = command.lower()
         self.zmq_socket.send_multipart([
             cmd_data["type"].encode("utf-8"),
-            "/".join(cmd_data["path"]).encode("utf-8"),
+            cmd_data["path"].encode("utf-8"),
             umsgpack.packb(cmd_data)
         ])
         self.zmq_socket.recv()


### PR DESCRIPTION
Fixes #5 

This means that opening a new window pointing to the same server will result in the same 3D scene being displayed, so it should not be necessary to pre-emptively or periodically re-transmit all the set_object commands. In addition, it should be safe to refresh the browser view at any time. 