### PR TITLE
Force tobytes() to use appropriate ordering

### DIFF
--- a/src/meshcat/geometry.py
+++ b/src/meshcat/geometry.py
@@ -274,7 +274,7 @@ def pack_numpy_array(x):
     return {
         u"itemSize": item_size(x),
         u"type": typename,
-        u"array": umsgpack.Ext(extcode, x.tobytes()),
+        u"array": umsgpack.Ext(extcode, x.tobytes('F')),
         u"normalized": False
     }
 
@@ -342,6 +342,3 @@ def PointCloud(position, color, **kwargs):
         PointsGeometry(position, color),
         PointsMaterial(**kwargs)
     )
-
-
-


### PR DESCRIPTION
This is sanity-checkable by attempting to publish a point cloud with some known structure -- e.g. a point cloud that should be a random set of points on the ground. Not sure how to test for that in a unit-test sort of framework, though.

Enables pretty viz (though I'm still fixing up some camera intrinsic stuff).

![image](https://user-images.githubusercontent.com/3066703/40449571-ce12ebda-5ea6-11e8-95d8-347c752dec4a.png)
