### PR TITLE
Added basic support of Line, LineSegment and LineLoop

### DIFF
--- a/src/meshcat/examples/lines.ipynb
+++ b/src/meshcat/examples/lines.ipynb
@@ -1,0 +1,177 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "You can open the visualizer by visiting the following URL:\n",
+      "http://127.0.0.1:7004/static/\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<div style=\"height: 400px; width: 600px; overflow-x: auto; overflow-y: hidden; resize: both\">\n",
+       "<iframe src=\"http://127.0.0.1:7004/static/\" style=\"width: 100%; height: 100%; border: none\"></iframe>\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import meshcat\n",
+    "import meshcat.geometry as g\n",
+    "import numpy as np\n",
+    "import time\n",
+    "\n",
+    "vis = meshcat.Visualizer()\n",
+    "vis.jupyter_cell()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create some random vertices and render them as individual, nonconnected, [LineSegments](https://threejs.org/docs/index.html#api/en/objects/LineSegments)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vis.delete()\n",
+    "vertices = np.random.random((3, 10)).astype(np.float32)\n",
+    "vis['lines_segments'].set_object(g.LineSegments(g.PointsGeometry(vertices)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Render as a single connected [Line](https://threejs.org/docs/index.html#api/en/objects/Line)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "line_vertices = np.array(vertices)\n",
+    "line_vertices[1, :] += 1\n",
+    "vis['line'].set_object(g.Line(g.PointsGeometry(line_vertices)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Render as a [LineLoop](https://threejs.org/docs/index.html#api/en/objects/LineLoop)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "line_loop = np.array(vertices)\n",
+    "line_loop[1, :] += 2\n",
+    "vis['line_loop'].set_object(g.LineLoop(g.PointsGeometry(line_loop)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Line can have mesh materials."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vis.delete()\n",
+    "vertices = np.random.random((3, 10)).astype(np.float32)\n",
+    "vis['basic'].set_object(g.Line(g.PointsGeometry(vertices), g.MeshBasicMaterial(color=0xff0000)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vphong = np.array(vertices)\n",
+    "vphong[1, :] += 1\n",
+    "vis['phong'].set_object(g.Line(g.PointsGeometry(vphong), g.MeshPhongMaterial(color=0xff0000)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vlamb = np.array(vertices)\n",
+    "vlamb[1, :] += 2\n",
+    "vis['lambert'].set_object(g.Line(g.PointsGeometry(vlamb), g.MeshLambertMaterial(color=0xff0000)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vtoon = np.array(vertices)\n",
+    "vtoon[1, :] += 3\n",
+    "vis['toon'].set_object(g.Line(g.PointsGeometry(vtoon), g.MeshToonMaterial(color=0xff0000)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Threejs also exposes attributes such as `color`, `linewidth`, `linecap` and `linejoin` using [LineBasicMaterial]( https://threejs.org/docs/#api/en/materials/LineBasicMaterial) and [LineDashMaterial]( https://threejs.org/docs/#api/en/materials/LineDashMaterial) materials. These have not been added."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/meshcat/geometry.py
+++ b/src/meshcat/geometry.py
@@ -388,3 +388,15 @@ def PointCloud(position, color, **kwargs):
         PointsGeometry(position, color),
         PointsMaterial(**kwargs)
     )
+
+
+class Line(Object):
+    _type = u"Line"
+
+
+class LineSegments(Object):
+    _type = u"LineSegments"
+
+
+class LineLoop(Object):
+    _type = u"LineLoop"


### PR DESCRIPTION
The changes were trivial in the end. I just added the following,

```python
class Line(Object):
    _type = u"Line"


class LineSegments(Object):
    _type = u"LineSegments"


class LineLoop(Object):
    _type = u"LineLoop"
```

![Rendering with LineSegment, Line and LineLoop](https://i.imgur.com/7rSPJy0.png)

I spend most of the time testing the different rending options (Line, LineSegement and LineLoop) in the included [lines.ipynb](https://github.com/danieljfarrell/meshcat-python/blob/master/src/meshcat/examples/lines.ipynb). In this notebook I also played around a little with using materials to give the lines different colours. It seems they can be rendered using standard mesh materials. 

![Rending lines with different materials](https://i.imgur.com/lLIfUmK.png)

I also thought about adding https://threejs.org/docs/#api/en/materials/LineBasicMaterial and https://threejs.org/docs/#api/en/materials/LineDashMaterial but decided against it so as to keep this pull request simple.