### PR TITLE
Added `from_stream` method to MeshGeometry subclasses.

### DIFF
--- a/src/meshcat/geometry.py
+++ b/src/meshcat/geometry.py
@@ -303,12 +303,12 @@ def pack_numpy_array(x):
 
 def data_from_stream(stream):
     if sys.version_info >= (3, 0):
-        if type(stream) == BytesIO:
+        if isinstance(stream, BytesIO):
             data = stream.read().decode(encoding='utf-8')
-        elif type(stream) == StringIO:
+        elif isinstance(stream, StringIO):
             data = stream.read()
         else:
-            raise ValueError('Stream must be StringIO or BytesIO, not {}'.format(type(stream)))
+            raise ValueError('Stream must be instance of StringIO or BytesIO, not {}'.format(type(stream)))
     else:
         data = stream.read()
     return data
@@ -372,12 +372,12 @@ class StlMeshGeometry(MeshGeometry):
     @staticmethod
     def from_stream(f):
         if sys.version_info >= (3, 0):
-            if type(f) == BytesIO:
+            if isinstance(f, BytesIO):
                 arr  = np.frombuffer(f.read(), dtype=np.uint8)
-            elif type(f) == StringIO:
+            elif isinstance(f, StringIO):
                 arr = np.frombuffer(bytes(f.read(), "utf-8"), dtype=np.uint8)
             else:
-                raise ValueError('Unexpected type')
+                raise ValueError('Stream must be instance of StringIO or BytesIO, not {}'.format(type(f)))
         else:
             arr  = np.frombuffer(f.read(), dtype=np.uint8)
         _, extcode = threejs_type(np.uint8)


### PR DESCRIPTION
### Changes

If mesh already exists in memory it is inefficient to save the mesh to a file and reload it. This can be avoided using streams.

```python
f = io.StringIO('mesh ascii')  # or io.BytesIO('mesh binary')
```

The `from_file` methods open the file and then load,

```python
@staticmethod
def from_file(fname):
    with open(fname, "r") as f:
        return MeshGeometry(f.read(), u"dae")
```

The `from_steam` methods skip the `with open` step and load the data in the stream directly.

```python
@staticmethod
def from_stream(f):
    return MeshGeometry(data_from_stream(f), u"dae")
```

`StringIO` changes quite a bit between Python 2 and Python 3 and I noticed you are supporting Python 2 so I made it work in both cases. `data_from_stream` looks like this,

```python
def data_from_stream(stream):
    if sys.version_info >= (3, 0):
        if type(stream) == BytesIO:
            data = stream.read().decode(encoding='utf-8')
        elif type(stream) == StringIO:
            data = stream.read()
        else:
            raise ValueError('Stream must be StringIO or BytesIO, not {}'.format(type(stream)))
    else:
        data = stream.read()
    return data
```

In Python 3 we first check if we are a string or a bytes stream and load accordingly. Python 2 only has `str` types so we can go ahead and just load that.

### Testing

Tests have been added and pass in both Python 2 and Python 3. The .obj, .stl (ascii and binary) and the .dae files from `tests/data` are loaded into streams and visualised. Loading the text from disk into a stream kind of defeats the purpose of using streams but the round trip is a good test and shows that it works.
