### PR TITLE
Expose/serve local files via the ZMQWebSocketBridge

### DIFF
--- a/src/meshcat/servers/zmqserver.py
+++ b/src/meshcat/servers/zmqserver.py
@@ -229,7 +229,10 @@ def main():
     if results.open:
         webbrowser.open(bridge.web_url, new=2)
 
-    bridge.run()
+    try:
+        bridge.run()
+    except KeyboardInterrupt:
+        pass
 
 if __name__ == '__main__':
     main()

--- a/src/meshcat/servers/zmqserver.py
+++ b/src/meshcat/servers/zmqserver.py
@@ -17,6 +17,9 @@ import tornado.ioloop
 import tornado.websocket
 import tornado.gen
 
+import mimetypes
+from mimetypes import guess_type
+
 import zmq
 from zmq.eventloop import ioloop
 from zmq.eventloop.zmqstream import ZMQStream
@@ -35,6 +38,8 @@ DEFAULT_FILESERVER_PORT = 7000
 MAX_ATTEMPTS = 1000
 DEFAULT_ZMQ_METHOD = "tcp"
 DEFAULT_ZMQ_PORT = 6000
+
+KNOWN_TYPES = ['stl', 'obj', 'dae', 'png', 'bmp', 'jpeg', 'jpg', 'mtl']
 
 MESHCAT_COMMANDS = ["set_transform", "set_object", "delete", "set_property", "set_animation"]
 
@@ -70,6 +75,28 @@ class WebSocketHandler(tornado.websocket.WebSocketHandler):
         self.bridge.websocket_pool.remove(self)
         print("closed:", self, file=sys.stderr)
 
+class FileHandler(tornado.web.RequestHandler):
+    def initialize(self, root):
+        self.root = root
+        mimetypes.add_type("model/vnd.collada+xml", ".dae")
+        mimetypes.add_type("text/plain", ".mtl")
+
+    def get(self, path_in):
+        if path_in[0] == '/':
+            path = path_in[1:]
+        else:
+            path = path_in
+        file_location = os.path.join(self.root, path)
+        filename, file_extension = os.path.splitext(path)
+        if any(ext == file_extension.lower() for ext in KNOWN_TYPES):
+            raise tornado.web.HTTPError(status_code=403)
+        if not os.path.isfile(file_location):
+            raise tornado.web.HTTPError(status_code=404)
+        content_type, _ = guess_type(file_location)
+        self.add_header('Content-Type', content_type)
+        with open(file_location) as source_file:
+            self.write(source_file.read())
+
 
 def create_command(data):
     """Encode the drawing command into a Javascript fetch() command for display."""
@@ -83,9 +110,15 @@ fetch("data:application/octet-binary;base64,{}")
 class ZMQWebSocketBridge(object):
     context = zmq.Context()
 
-    def __init__(self, zmq_url=None, host="127.0.0.1", port=None):
+    def __init__(self, zmq_url=None, host="127.0.0.1", port=None, path_root=None):
         self.host = host
         self.websocket_pool = set()
+        if path_root is None:
+            self.path_root = None
+        else:
+            self.path_root = path_root
+            print("Enabling file service with root at '" + self.path_root + "'")
+            print("Allowed file extensions: ", KNOWN_TYPES)
         self.app = self.make_app()
         self.ioloop = tornado.ioloop.IOLoop.current()
 
@@ -102,14 +135,17 @@ class ZMQWebSocketBridge(object):
             self.app.listen(port)
             self.fileserver_port = port
         self.web_url = "http://{host}:{port}/static/".format(host=self.host, port=self.fileserver_port)
+        self.file_url = "http://{host}:{port}/files/".format(host=self.host, port=self.fileserver_port)
 
         self.tree = SceneTree()
 
     def make_app(self):
-        return tornado.web.Application([
-            (r"/static/(.*)", tornado.web.StaticFileHandler, {"path": VIEWER_ROOT, "default_filename": VIEWER_HTML}),
-            (r"/", WebSocketHandler, {"bridge": self})
-        ])
+        handlers = []
+        handlers.append((r"/static/(.*)", tornado.web.StaticFileHandler, {"path": VIEWER_ROOT, "default_filename": VIEWER_HTML}))
+        if not self.path_root is None:
+            handlers.append((r"/files/(.*)", FileHandler, {"root": self.path_root}))
+        handlers.append((r"/", WebSocketHandler, {"bridge": self}))
+        return tornado.web.Application(handlers)
 
     def wait_for_websockets(self):
         if len(self.websocket_pool) > 0:
@@ -121,6 +157,8 @@ class ZMQWebSocketBridge(object):
         cmd = frames[0].decode("utf-8")
         if cmd == "url":
             self.zmq_socket.send(self.web_url.encode("utf-8"))
+        elif cmd == "file_url":
+            self.zmq_socket.send(self.file_url.encode("utf-8"))
         elif cmd == "wait":
             self.ioloop.add_callback(self.wait_for_websockets)
         elif cmd in MESHCAT_COMMANDS:
@@ -221,11 +259,14 @@ def main():
 
     parser = argparse.ArgumentParser(description="Serve the MeshCat HTML files and listen for ZeroMQ commands")
     parser.add_argument('--zmq-url', '-z', type=str, nargs="?", default=None)
+    parser.add_argument('--file-root', '-f', type=str, nargs="?", default=None)
     parser.add_argument('--open', '-o', action="store_true")
     results = parser.parse_args()
-    bridge = ZMQWebSocketBridge(zmq_url=results.zmq_url)
+    bridge = ZMQWebSocketBridge(zmq_url=results.zmq_url, path_root=results.file_root)
     print("zmq_url={:s}".format(bridge.zmq_url))
     print("web_url={:s}".format(bridge.web_url))
+    if not bridge.path_root is None:
+        print("file_url={:s}".format(bridge.file_url))
     if results.open:
         webbrowser.open(bridge.web_url, new=2)
 

--- a/src/meshcat/servers/zmqserver.py
+++ b/src/meshcat/servers/zmqserver.py
@@ -94,7 +94,7 @@ class FileHandler(tornado.web.RequestHandler):
             raise tornado.web.HTTPError(status_code=404)
         content_type, _ = guess_type(file_location)
         self.add_header('Content-Type', content_type)
-        with open(file_location) as source_file:
+        with open(file_location, "rb") as source_file:
             self.write(source_file.read())
 
 

--- a/src/meshcat/visualizer.py
+++ b/src/meshcat/visualizer.py
@@ -105,7 +105,7 @@ class Visualizer:
 
     def __init__(self, zmq_url=None, window=None, args=[]):
         if window is None:
-            self.window = ViewerWindow(zmq_url=zmq_url, start_server=(zmq_url is None), args)
+            self.window = ViewerWindow(zmq_url=zmq_url, start_server=(zmq_url is None), args=args)
         else:
             self.window = window
         self.path = Path(("meshcat",))

--- a/src/meshcat/visualizer.py
+++ b/src/meshcat/visualizer.py
@@ -32,10 +32,10 @@ def match_web_url(line):
 class ViewerWindow:
     context = zmq.Context()
 
-    def __init__(self, zmq_url, start_server):
+    def __init__(self, zmq_url, start_server, args):
         if start_server:
             # Need -u for unbuffered output: https://stackoverflow.com/a/25572491
-            args = [sys.executable, "-u", "-m", "meshcat.servers.zmqserver"]
+            args = [sys.executable, "-u", "-m", "meshcat.servers.zmqserver"] + args
             if zmq_url is not None:
                 args.append("--zmq-url")
                 args.append(zmq_url)
@@ -103,9 +103,9 @@ class ViewerWindow:
 class Visualizer:
     __slots__ = ["window", "path"]
 
-    def __init__(self, zmq_url=None, window=None):
+    def __init__(self, zmq_url=None, window=None, args=[]):
         if window is None:
-            self.window = ViewerWindow(zmq_url=zmq_url, start_server=(zmq_url is None))
+            self.window = ViewerWindow(zmq_url=zmq_url, start_server=(zmq_url is None), args)
         else:
             self.window = window
         self.path = Path(("meshcat",))
@@ -171,13 +171,15 @@ class Visualizer:
 if __name__ == '__main__':
     import time
     import sys
-
+    args = []
     if len(sys.argv) > 1:
         zmq_url = sys.argv[1]
+        if len(sys.argv) > 2:
+            args = sys.argv[2:]
     else:
         zmq_url = None
 
-    window = ViewerWindow(zmq_url, zmq_url is None, True)
+    window = ViewerWindow(zmq_url, zmq_url is None, True, args)
 
     while True:
         time.sleep(100)


### PR DESCRIPTION
 - Adds `args` argument to the initializer of `ViewerWindow`. These `args` will be passed onto the `ZMQWebSocketBridge`. `Visualizer` passes its command line arguments onto the `ViewerWindow`.
 - Adds keyboard interrupt handling for the `Visualizer`.

Reverted the below:
> - Upstreams the viewer. Now supporting loading meshes with textures.
> - Adds file handler to the `ZMQWebSocketBridge`
>     - Only known file types are served: stl, obj, dae, png, bmp, jpeg, jpg, mtl
>     - Adds `--file-root` `-f`argument. This path is the relative path for searching for files. It can be set to `/` (`-f=/`) to allow access to the whole file system (useful when exposing ROS packages).
>     - Exposes a file serving URL `http://[your_url]/files/`. Http request to this URL will strip this string and prepend the `file-root` to look for files on the server: `http://[your_url]/files/my_file.obj` will return file from `[file-root]/my_file.obj`.
>     - Adds ZMQ handler that return the file URL.
