### PR TITLE
fix zmq installation apt package

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -44,7 +44,7 @@ Ubuntu/Debian:
 
 ::
 
-    apt-get install libzmq3
+    apt-get install libzmq3-dev
 
 Homebrew:
 


### PR DESCRIPTION
To install `libzmq3` in apt you need to do `sudo apt-get install libzmq3-dev` because the package `libzmq3` does not exist.

Tested and installed on Ubuntu 16.04.