### PR TITLE
Save scene into static JSON

### DIFF
--- a/src/meshcat/servers/zmqserver.py
+++ b/src/meshcat/servers/zmqserver.py
@@ -71,7 +71,7 @@ class WebSocketHandler(tornado.websocket.WebSocketHandler):
         print("closed:", self, file=sys.stderr)
 
 
-def create_command(data) -> str:
+def create_command(data):
     """Encode the drawing command into a Javascript fetch() command for display."""
     return """
 fetch("data:application/octet-binary;base64,{}")

--- a/src/meshcat/servers/zmqserver.py
+++ b/src/meshcat/servers/zmqserver.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import base64
 import os
 import sys
 import multiprocessing
@@ -68,6 +69,11 @@ class WebSocketHandler(tornado.websocket.WebSocketHandler):
     def on_close(self):
         self.bridge.websocket_pool.remove(self)
         print("closed:", self, file=sys.stderr)
+
+
+def create_base64(data):
+    """Create a base64 encoded version of the Three.js data that can be embedded."""
+    return base64.b64encode(data)
 
 
 class ZMQWebSocketBridge(object):
@@ -139,9 +145,9 @@ class ZMQWebSocketBridge(object):
             output = b""
             for node in walk(self.tree):
                 if node.object is not None:
-                    output += node.object
+                    output += create_base64(node.object)
                 if node.transform is not None:
-                    output += node.transform
+                    output += create_base64(node.transform)
             self.zmq_socket.send(output)
         else:
             self.zmq_socket.send(b"error: unrecognized comand")

--- a/src/meshcat/servers/zmqserver.py
+++ b/src/meshcat/servers/zmqserver.py
@@ -133,6 +133,16 @@ class ZMQWebSocketBridge(object):
                 else:
                     self.tree = SceneTree()
             self.zmq_socket.send(b"ok")
+        elif cmd == "get_scene":
+            # when the server gets this command, return the tree
+            # as a series of msgpack-backed binary blobs
+            output = b""
+            for node in walk(self.tree):
+                if node.object is not None:
+                    output += node.object
+                if node.transform is not None:
+                    output += node.transform
+            self.zmq_socket.send(output)
         else:
             self.zmq_socket.send(b"error: unrecognized comand")
 

--- a/src/meshcat/tests/test_drawing.py
+++ b/src/meshcat/tests/test_drawing.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import unittest
 import subprocess
 import sys
+import tempfile
 import os
 
 if sys.version_info >= (3, 0):
@@ -197,3 +198,14 @@ class TestCameraAnimation(VisualizerTest):
         with animation.at_frame(v, 30) as frame_vis:
             frame_vis["/Cameras/default/rotated/<object>"].set_property("zoom", "number", 0.5)
         v.set_animation(animation)
+
+
+class TestStaticHTML(TestDrawing):
+    def runTest(self):
+        """Test that we can generate a static HTML file from the Drawing test case and view it."""
+        super(TestStaticHTML, self).runTest()
+        res = self.vis.static_html()
+        # save to a file
+        temp = tempfile.mkstemp(suffix=".html")
+        with open(temp[1], "w") as f:
+            f.write(res)

--- a/src/meshcat/visualizer.py
+++ b/src/meshcat/visualizer.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import atexit
-import os
 import sys
 import subprocess
 import webbrowser

--- a/src/meshcat/visualizer.py
+++ b/src/meshcat/visualizer.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import atexit
-import base64
 import os
 import sys
 import subprocess
@@ -101,13 +100,13 @@ class ViewerWindow:
         return self.zmq_socket.recv()
 
 
-def create_command(data):
-    """Encode the bytestream from the ZMQ server as a string we can embed into JS."""
+def create_command(data) -> str:
+    """Encode the b64-encoded string from the ZMQ server into something we can embed into JS."""
     return """
 fetch("data:application/octet-binary;base64,{}")
     .then(res => res.arrayBuffer())
     .then(buffer => viewer.handle_command_bytearray(new Uint8Array(buffer)));
-    """.format(base64.b64encode(data).decode("utf-8"))
+    """.format(data.decode("utf-8"))
 
 
 class Visualizer:

--- a/src/meshcat/visualizer.py
+++ b/src/meshcat/visualizer.py
@@ -94,7 +94,7 @@ class ViewerWindow:
         self.zmq_socket.recv()
 
     def get_scene(self):
-        """Get the scene as a binary blob from the ZMQ server."""
+        """Get the static HTML from the ZMQ server."""
         self.zmq_socket.send(b"get_scene")
         # we receive the HTML as utf-8-encoded, so decode here
         return self.zmq_socket.recv().decode('utf-8')

--- a/src/meshcat/visualizer.py
+++ b/src/meshcat/visualizer.py
@@ -95,7 +95,7 @@ class ViewerWindow:
 
 
 class Visualizer:
-    __slots__ = ["window", "path"]
+    __slots__ = ["window", "path", "tree"]
 
     def __init__(self, zmq_url=None, window=None):
         if window is None:
@@ -103,6 +103,7 @@ class Visualizer:
         else:
             self.window = window
         self.path = Path(("meshcat",))
+        self.tree = 
 
     @staticmethod
     def view_into(window, path):
@@ -148,6 +149,57 @@ class Visualizer:
 
     def close(self):
         self.window.close()
+
+    # def static_html(self):
+    #     """
+    #     Generate and save a static HTML file that standalone encompasses the visualizer and contents.
+    #     
+    #     Ask the server for the scene (since the server knows it), and pack it all into an
+    #     HTML blob for future use.
+    #     """
+    #     viewer_commands = String[]
+
+    #     foreach(core.tree) do node
+    #         if node.object !== nothing
+    #             push!(viewer_commands, _create_command(node.object));
+    #         end
+    #         if node.transform !== nothing
+    #             push!(viewer_commands, _create_command(node.transform));
+    #         end
+    #         for data in values(node.properties)
+    #             push!(viewer_commands, _create_command(data));
+    #         end
+    #         if node.animation !== nothing
+    #             push!(viewer_commands, _create_command(node.animation))
+    #         end
+    #     end
+
+    #     return """
+    #         <!DOCTYPE html>
+    #         <html>
+    #             <head> <meta charset=utf-8> <title>MeshCat</title> </head>
+    #             <body>
+    #                 <div id="meshcat-pane">
+    #                 </div>
+    #                 <script>
+    #                     $(open(s -> read(s, String), joinpath(VIEWER_ROOT, "main.min.js")))
+    #                 </script>
+    #                 <script>
+    #                     var viewer = new MeshCat.Viewer(document.getElementById("meshcat-pane"));
+    #                     $(join(viewer_commands, '\n'))
+    #                 </script>
+    #                  <style>
+    #                     body {margin: 0; }
+    #                     #meshcat-pane {
+    #                         width: 100vw;
+    #                         height: 100vh;
+    #                         overflow: hidden;
+    #                     }
+    #                 </style>
+    #                 <script id="embedded-json"></script>
+    #             </body>
+    #         </html>
+    #     """
 
     def __repr__(self):
         return "<Visualizer using: {window} at path: {path}>".format(window=self.window, path=self.path)

--- a/src/meshcat/visualizer.py
+++ b/src/meshcat/visualizer.py
@@ -110,7 +110,7 @@ fetch("data:application/octet-binary;base64,{}")
 
 
 class Visualizer:
-    __slots__ = ["window", "path", "tree"]
+    __slots__ = ["window", "path"]
 
     def __init__(self, zmq_url=None, window=None):
         if window is None:


### PR DESCRIPTION
Adds the capability to generate a standalone static HTML page from the visualizer object.

Usage:

```
vis = Visualizer()
res = vis.statc_html()
with open("test.html", "w") as f:
     f.write(res)
```

At this point you have a `test.html` file that standalone has your entire Meshcat scene in it.