### PR TITLE
pass PYTHONPATH to Popen

### DIFF
--- a/src/meshcat/visualizer.py
+++ b/src/meshcat/visualizer.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import atexit
+import os
 import sys
 import subprocess
 import webbrowser
@@ -40,7 +41,10 @@ class ViewerWindow:
             if zmq_url is not None:
                 args.append("--zmq-url")
                 args.append(zmq_url)
-            self.server_proc = subprocess.Popen(args, stdout=subprocess.PIPE)
+            # Note: Pass PYTHONPATH to be robust to workflows like Google Colab,
+            # where meshcat might have been added directly via sys.path.append.
+            env = {'PYTHONPATH': os.path.dirname(os.path.dirname(__file__))}
+            self.server_proc = subprocess.Popen(args, stdout=subprocess.PIPE, env=env)
             self.zmq_url = match_zmq_url(self.server_proc.stdout.readline().strip().decode("utf-8"))
             self.web_url = match_web_url(self.server_proc.stdout.readline().strip().decode("utf-8"))
 


### PR DESCRIPTION
I've got meshcat working on colab ([simple version](https://colab.research.google.com/drive/1O-WgLtqKGuHKEeD4CFT69870dPEJRsQJ), [manipulation teleop demo](https://colab.research.google.com/drive/1PvEXUdmwL_W9yzncyJR7fOHYDLUXj-P2)) now, which makes me very happy.  But I had to do a bunch of little hacks to get things to work.  I'll upstream the ones that I think make sense.

This is the first one.  WDYT?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rdeits/meshcat-python/65)
<!-- Reviewable:end -->
