### PR TITLE
Generalizes "start_server" logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
 os:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setup(name="meshcat",
       "u-msgpack-python >= 2.4.1",
       "numpy >= 1.14.0" if sys.version_info >= (3, 0) else "numpy >= 1.14.0, < 1.17",
       "tornado >= 4.0.0" if sys.version_info >= (3, 0) else "tornado >= 4.0.0, < 6.0",
-      "pyzmq >= 17.0.0"
+      "pyzmq >= 17.0.0",
+      "pyngrok >= 4.1.6"
     ],
     zip_safe=False,
     include_package_data=True

--- a/src/meshcat/servers/zmqserver.py
+++ b/src/meshcat/servers/zmqserver.py
@@ -40,7 +40,7 @@ def match_zmq_url(line):
 def match_web_url(line):
     return capture(r"^web_url=(.*)$", line)
 
-def StartZmqServerAsSubprocess(zmq_url=None, server_args=[]):
+def start_zmq_server_as_subprocess(zmq_url=None, server_args=[]):
     """
     Starts the ZMQ server as a subprocess, passing *args through popen.
     Optional Keyword Arguments:
@@ -65,7 +65,10 @@ def StartZmqServerAsSubprocess(zmq_url=None, server_args=[]):
     if sys.version_info.major >= 3:
         kwargs['start_new_session'] = True
     server_proc = subprocess.Popen(args, **kwargs)
-    zmq_url = match_zmq_url(server_proc.stdout.readline().strip().decode("utf-8"))
+    line = ""
+    while "zmq_url" not in line:
+        line = server_proc.stdout.readline().strip().decode("utf-8")
+    zmq_url = match_zmq_url(line)
     web_url = match_web_url(server_proc.stdout.readline().strip().decode("utf-8"))
 
     def cleanup(server_proc):
@@ -211,6 +214,7 @@ class ZMQWebSocketBridge(object):
                         kwargs['start_new_session'] = True
                 config = pyngrok.conf.PyngrokConfig(**kwargs)
                 self.web_url = pyngrok.ngrok.connect(self.fileserver_port, "http", pyngrok_config=config) + "/static/"
+                print("\n")  # ensure any pyngrok output is properly terminated.
 
                 def cleanup():
                     pyngrok.ngrok.kill()
@@ -220,9 +224,6 @@ class ZMQWebSocketBridge(object):
             except ImportError as e:
                 if "pyngrok" in e.__class__.__name__:
                     raise(Exception("You must install pyngrok (e.g. via `pip install pyngrok`)."))
-            except:
-                raise
-
 
         self.tree = SceneTree()
 

--- a/src/meshcat/tests/test_start_server.py
+++ b/src/meshcat/tests/test_start_server.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import, division, print_function
+
+import unittest
+
+from meshcat.servers.zmqserver import StartZmqServerAsSubprocess
+
+class TestStartZmqServer(unittest.TestCase):
+    """
+    Test the StartZmqServerAsSubprocess method.
+    """
+
+    def test_default_args(self):
+        proc, zmq_url, web_url = StartZmqServerAsSubprocess()
+        self.assertIn("127.0.0.1", web_url)
+
+    def test_ngrok(self):
+        proc, zmq_url, web_url = StartZmqServerAsSubprocess( server_args=["--ngrok_http_tunnel"])
+        self.assertNotIn("127.0.0.1", web_url)

--- a/src/meshcat/tests/test_start_server.py
+++ b/src/meshcat/tests/test_start_server.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import unittest
 
-from meshcat.servers.zmqserver import StartZmqServerAsSubprocess
+from meshcat.servers.zmqserver import start_zmq_server_as_subprocess
 
 class TestStartZmqServer(unittest.TestCase):
     """
@@ -10,9 +10,10 @@ class TestStartZmqServer(unittest.TestCase):
     """
 
     def test_default_args(self):
-        proc, zmq_url, web_url = StartZmqServerAsSubprocess()
+        proc, zmq_url, web_url = start_zmq_server_as_subprocess()
         self.assertIn("127.0.0.1", web_url)
 
     def test_ngrok(self):
-        proc, zmq_url, web_url = StartZmqServerAsSubprocess( server_args=["--ngrok_http_tunnel"])
+        proc, zmq_url, web_url = start_zmq_server_as_subprocess( server_args=["--ngrok_http_tunnel"])
+        self.assertIsNotNone(web_url)
         self.assertNotIn("127.0.0.1", web_url)

--- a/src/meshcat/visualizer.py
+++ b/src/meshcat/visualizer.py
@@ -1,58 +1,24 @@
 from __future__ import absolute_import, division, print_function
 
-import atexit
-import os
 import sys
-import subprocess
 import webbrowser
 
 import umsgpack
 import numpy as np
 import zmq
-import re
 from IPython.display import HTML
 
 from .path import Path
 from .commands import SetObject, SetTransform, Delete, SetProperty, SetAnimation
 from .geometry import MeshPhongMaterial
-
-
-def capture(pattern, s):
-    match = re.match(pattern, s)
-    if not match:
-        raise ValueError("Could not match {:s} with pattern {:s}".format(s, pattern))
-    else:
-        return match.groups()[0]
-
-def match_zmq_url(line):
-    return capture(r"^zmq_url=(.*)$", line)
-
-def match_web_url(line):
-    return capture(r"^web_url=(.*)$", line)
-
+from .servers.zmqserver import StartZmqServerAsSubprocess
 
 class ViewerWindow:
     context = zmq.Context()
 
-    def __init__(self, zmq_url, start_server, args):
+    def __init__(self, zmq_url, start_server, server_args):
         if start_server:
-            # Need -u for unbuffered output: https://stackoverflow.com/a/25572491
-            args = [sys.executable, "-u", "-m", "meshcat.servers.zmqserver"] + args
-            if zmq_url is not None:
-                args.append("--zmq-url")
-                args.append(zmq_url)
-            # Note: Pass PYTHONPATH to be robust to workflows like Google Colab,
-            # where meshcat might have been added directly via sys.path.append.
-            env = {'PYTHONPATH': os.path.dirname(os.path.dirname(__file__))}
-            self.server_proc = subprocess.Popen(args, stdout=subprocess.PIPE, env=env)
-            self.zmq_url = match_zmq_url(self.server_proc.stdout.readline().strip().decode("utf-8"))
-            self.web_url = match_web_url(self.server_proc.stdout.readline().strip().decode("utf-8"))
-
-            def cleanup():
-                self.server_proc.kill()
-                self.server_proc.wait()
-
-            atexit.register(cleanup)
+            self.server_proc, self.zmq_url, self.web_url = StartZmqServerAsSubprocess(zmq_url=zmq_url, server_args=server_args)
 
         else:
             self.server_proc = None
@@ -69,8 +35,6 @@ class ViewerWindow:
 
         print("You can open the visualizer by visiting the following URL:")
         print(self.web_url)
-
-
 
     def connect_zmq(self):
         self.zmq_socket = self.context.socket(zmq.REQ)
@@ -112,9 +76,9 @@ def srcdoc_escape(x):
 class Visualizer:
     __slots__ = ["window", "path"]
 
-    def __init__(self, zmq_url=None, window=None, args=[]):
+    def __init__(self, zmq_url=None, window=None, server_args=[]):
         if window is None:
-            self.window = ViewerWindow(zmq_url=zmq_url, start_server=(zmq_url is None), args=args)
+            self.window = ViewerWindow(zmq_url=zmq_url, start_server=(zmq_url is None), server_args=server_args)
         else:
             self.window = window
         self.path = Path(("meshcat",))

--- a/src/meshcat/visualizer.py
+++ b/src/meshcat/visualizer.py
@@ -11,14 +11,15 @@ from IPython.display import HTML
 from .path import Path
 from .commands import SetObject, SetTransform, Delete, SetProperty, SetAnimation
 from .geometry import MeshPhongMaterial
-from .servers.zmqserver import StartZmqServerAsSubprocess
+from .servers.zmqserver import start_zmq_server_as_subprocess
 
 class ViewerWindow:
     context = zmq.Context()
 
     def __init__(self, zmq_url, start_server, server_args):
         if start_server:
-            self.server_proc, self.zmq_url, self.web_url = StartZmqServerAsSubprocess(zmq_url=zmq_url, server_args=server_args)
+            self.server_proc, self.zmq_url, self.web_url = start_zmq_server_as_subprocess(
+                zmq_url=zmq_url, server_args=server_args)
 
         else:
             self.server_proc = None


### PR DESCRIPTION
pulls it out of Visualizer class so that it can used to start a stand-alone server from python / jupyter
adds support for ngrok http tunnels, which allows one to make a public url from a machine that does not have a public hostname.
did a little dance to make sure it still works with python2.7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rdeits/meshcat-python/68)
<!-- Reviewable:end -->
