### PR TITLE
Remove unused import from collections.

### DIFF
--- a/src/meshcat/servers/zmqserver.py
+++ b/src/meshcat/servers/zmqserver.py
@@ -7,7 +7,6 @@ import re
 import sys
 import subprocess
 import multiprocessing
-from collections import deque
 
 if sys.version_info >= (3, 0):
     ADDRESS_IN_USE_ERROR = OSError


### PR DESCRIPTION
It was triggering deprecation warnings on ubuntu focal:
"Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working".
and, it turns out, was not actually being used.