### PR TITLE
zmqserver can cache objects

### DIFF
--- a/src/meshcat/servers/zmqserver.py
+++ b/src/meshcat/servers/zmqserver.py
@@ -250,7 +250,12 @@ class ZMQWebSocketBridge(object):
                 return
             path = list(filter(lambda x: len(x) > 0, frames[1].decode("utf-8").split("/")))
             data = frames[2]
-            self.forward_to_websockets(frames)
+            # Support caching of objects (note: even UUIDs have to match).
+            cache_hit = (cmd == "set_object" and 
+                         find_node(self.tree, path).object and 
+                         find_node(self.tree, path).object == data)
+            if not cache_hit:
+                self.forward_to_websockets(frames)
             if cmd == "set_transform":
                 find_node(self.tree, path).transform = data
             elif cmd == "set_object":


### PR DESCRIPTION
If the `zmqserver` gets a `set_object` command that sets precisely the same object data on precisely the same path that already exists, then do not forward it to the connected websockets.

This makes a *dramatic* improvement in the workflow of using meshcat on colab (at least as we use it in drake), because we don't have to repeatedly download large meshfiles from repeated simulations.