### PR TITLE
Bugfix: when creating a new subprocess copy existing environmental variables and add PYTHONPATH to those

### DIFF
--- a/src/meshcat/servers/zmqserver.py
+++ b/src/meshcat/servers/zmqserver.py
@@ -54,7 +54,12 @@ def start_zmq_server_as_subprocess(zmq_url=None, server_args=[]):
         args.append(*server_args)
     # Note: Pass PYTHONPATH to be robust to workflows like Google Colab,
     # where meshcat might have been added directly via sys.path.append.
-    env = {'PYTHONPATH': os.path.dirname(os.path.dirname(os.path.dirname(__file__)))}
+    # Copy existing environmental variables as some of them might be needed
+    # e.g. on Windows SYSTEMROOT and PATH
+    env = os.environ
+    my_env = {
+        'PYTHONPATH': os.path.dirname(os.path.dirname(os.path.dirname(__file__)))}
+    env.update(my_env)
     kwargs = { 
         'stdout': subprocess.PIPE,
         'env': env


### PR DESCRIPTION
This prevents errors on Windows

As suggested in https://www.scivision.dev/python-calling-python-subprocess/

At least PATH and SYSTEMROOT are necessary on windows to prevent the following error:
"Fatal Python error: _Py_HashRandomization_Init: failed to get random numbers to initialize Python"