### PR TITLE
support pyngrok 5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name="meshcat",
       "numpy >= 1.14.0" if sys.version_info >= (3, 0) else "numpy >= 1.14.0, < 1.17",
       "tornado >= 4.0.0" if sys.version_info >= (3, 0) else "tornado >= 4.0.0, < 6.0",
       "pyzmq >= 17.0.0",
-      "pyngrok >= 4.1.6"
+      "pyngrok >= 4.1.6" if sys.version_info >= (3, 0) else "pyngrok >= 4.1.6, < 5.0.0"
     ],
     zip_safe=False,
     include_package_data=True

--- a/src/meshcat/servers/zmqserver.py
+++ b/src/meshcat/servers/zmqserver.py
@@ -57,6 +57,7 @@ def start_zmq_server_as_subprocess(zmq_url=None, server_args=[]):
     env = {'PYTHONPATH': os.path.dirname(os.path.dirname(os.path.dirname(__file__)))}
     kwargs = { 
         'stdout': subprocess.PIPE,
+        'stderr': subprocess.PIPE,
         'env': env
     }
     # Use start_new_session if it's available. Without it, in jupyter the server
@@ -67,6 +68,11 @@ def start_zmq_server_as_subprocess(zmq_url=None, server_args=[]):
     line = ""
     while "zmq_url" not in line:
         line = server_proc.stdout.readline().strip().decode("utf-8")
+        if server_proc.poll() is not None:
+            outs, errs = server_proc.communicate()
+            print(outs.decode("utf-8"))
+            print(errs.decode("utf-8"))
+            raise RuntimeError("the meshcat server process exited prematurely with exit code " + str(server_proc.poll()))
     zmq_url = match_zmq_url(line)
     web_url = match_web_url(server_proc.stdout.readline().strip().decode("utf-8"))
 

--- a/src/meshcat/servers/zmqserver.py
+++ b/src/meshcat/servers/zmqserver.py
@@ -218,9 +218,16 @@ class ZMQWebSocketBridge(object):
                 if sys.version_info.major >= 3:
                         kwargs['start_new_session'] = True
                 config = pyngrok.conf.PyngrokConfig(**kwargs)
-                self.web_url = pyngrok.ngrok.connect(self.fileserver_port, "http", pyngrok_config=config) + "/static/"
-                print("\n")  # ensure any pyngrok output is properly terminated.
+                self.web_url = pyngrok.ngrok.connect(self.fileserver_port, "http", pyngrok_config=config)
 
+                # pyngrok >= 5.0.0 returns an NgrokTunnel object instead of the string.
+                if sys.version_info.major < 3:
+                    self.web_url = self.web_url.decode("utf-8")
+                elif not isinstance(self.web_url, str):
+                    self.web_url = self.web_url.public_url
+                self.web_url += "/static/"
+
+                print("\n")  # ensure any pyngrok output is properly terminated.
                 def cleanup():
                     pyngrok.ngrok.kill()
 

--- a/src/meshcat/servers/zmqserver.py
+++ b/src/meshcat/servers/zmqserver.py
@@ -250,7 +250,12 @@ class ZMQWebSocketBridge(object):
                 return
             path = list(filter(lambda x: len(x) > 0, frames[1].decode("utf-8").split("/")))
             data = frames[2]
-            self.forward_to_websockets(frames)
+            # Support caching of objects (note: even UUIDs have to match).
+            cache_hit = (cmd == "set_object" and 
+                         find_node(self.tree, path).object and 
+                         find_node(self.tree, path).object == data)
+            if not cache_hit:
+                self.forward_to_websockets(frames)
             if cmd == "set_transform":
                 find_node(self.tree, path).transform = data
             elif cmd == "set_object":


### PR DESCRIPTION
Related to https://github.com/RussTedrake/manipulation/issues/93

pyngrok 5.0.0 change the return type of the connect method. I've added logic to handle both versions. I've also made the output from the zmq server more robust when the subprocess fails (it was currently silent).

since we don't test pyngrok locally and I want to show you multiple versions, i've put a test case here: https://colab.research.google.com/drive/1N7X9keUQJwPWSrcX01rOfkNW6v_N9Lyv#scrollTo=KIKt347N_g0n

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rdeits/meshcat-python/80)
<!-- Reviewable:end -->
