### PR TITLE
New feature: capture image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist
 
 venv*
 .pytest_cache
+.vscode

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(name="meshcat",
       "tornado >= 4.0.0",
       "pyzmq >= 17.0.0",
       "pyngrok >= 4.1.6",
+      "pillow >= 7.0.0"
     ],
     zip_safe=False,
     include_package_data=True

--- a/src/meshcat/commands.py
+++ b/src/meshcat/commands.py
@@ -44,6 +44,17 @@ class SetTransform:
             u"matrix": list(self.matrix.T.flatten())
         }
 
+class CaptureImage:
+    __slots__ = ["save_path"]
+    def __init__(self, save_path=""):
+        self.save_path = save_path
+
+    def lower(self):
+        return {
+            u"type": u"capture_image",
+            u"save_path": self.save_path.lower()
+        }
+
 
 class Delete:
     __slots__ = ["path"]

--- a/src/meshcat/commands.py
+++ b/src/meshcat/commands.py
@@ -45,14 +45,10 @@ class SetTransform:
         }
 
 class CaptureImage:
-    __slots__ = ["save_path"]
-    def __init__(self, save_path=""):
-        self.save_path = save_path
 
     def lower(self):
         return {
-            u"type": u"capture_image",
-            u"save_path": self.save_path.lower()
+            u"type": u"capture_image"
         }
 
 

--- a/src/meshcat/servers/zmqserver.py
+++ b/src/meshcat/servers/zmqserver.py
@@ -7,6 +7,7 @@ import re
 import sys
 import subprocess
 import multiprocessing
+import json
 
 import tornado.web
 import tornado.ioloop
@@ -129,7 +130,6 @@ class WebSocketHandler(tornado.websocket.WebSocketHandler):
 
     def on_message(self, message):
         try:
-            import json
             message = json.loads(message)
             self.bridge.send_image(message['data'])
             return

--- a/src/meshcat/servers/zmqserver.py
+++ b/src/meshcat/servers/zmqserver.py
@@ -260,7 +260,6 @@ class ZMQWebSocketBridge(object):
         elif cmd == "wait":
             self.ioloop.add_callback(self.wait_for_websockets)
         elif cmd == "capture_image":
-            save_path = frames[1].decode("utf-8")
             if len(self.websocket_pool) > 0:
                 self.forward_to_websockets(frames)  # on_message callback should handle the pb
             else:

--- a/src/meshcat/visualizer.py
+++ b/src/meshcat/visualizer.py
@@ -68,11 +68,11 @@ class ViewerWindow:
         # we receive the HTML as utf-8-encoded, so decode here
         return self.zmq_socket.recv().decode('utf-8')
 
-    def get_image(self, save_path=""):
-        cmd_data = CaptureImage(save_path).lower()
+    def get_image(self):
+        cmd_data = CaptureImage().lower()
         self.zmq_socket.send_multipart([
             cmd_data["type"].encode("utf-8"),
-            cmd_data["save_path"].encode("utf-8"),
+            "".encode("utf-8"),
             umsgpack.packb(cmd_data)
         ])
         img_bytes = self.zmq_socket.recv()
@@ -158,9 +158,9 @@ class Visualizer:
     def set_animation(self, animation, play=True, repetitions=1):
         return self.window.send(SetAnimation(animation, play=play, repetitions=repetitions))
 
-    def get_image(self, save_path=""):
+    def get_image(self):
         """Save an image"""
-        return self.window.get_image(save_path)
+        return self.window.get_image()
 
     def delete(self):
         return self.window.send(Delete(self.path))

--- a/src/meshcat/visualizer.py
+++ b/src/meshcat/visualizer.py
@@ -100,7 +100,6 @@ class Visualizer:
         vis.path = path
         return vis
 
-        viewer = meshcat.Visualizer()
     def open(self):
         self.window.open()
         return self

--- a/src/meshcat/visualizer.py
+++ b/src/meshcat/visualizer.py
@@ -2,7 +2,10 @@ import webbrowser
 import umsgpack
 import numpy as np
 import zmq
+import io
+from PIL import Image        
 from IPython.display import HTML
+
 
 from .path import Path
 from .commands import SetObject, SetTransform, Delete, SetProperty, SetAnimation, CaptureImage
@@ -66,8 +69,6 @@ class ViewerWindow:
         return self.zmq_socket.recv().decode('utf-8')
 
     def get_image(self, save_path=""):
-        import io
-        from PIL import Image
         cmd_data = CaptureImage(save_path).lower()
         self.zmq_socket.send_multipart([
             cmd_data["type"].encode("utf-8"),

--- a/src/meshcat/visualizer.py
+++ b/src/meshcat/visualizer.py
@@ -68,7 +68,6 @@ class ViewerWindow:
     def get_image(self, save_path=""):
         import io
         from PIL import Image
-        import base64
         cmd_data = CaptureImage(save_path).lower()
         self.zmq_socket.send_multipart([
             cmd_data["type"].encode("utf-8"),
@@ -76,7 +75,6 @@ class ViewerWindow:
             umsgpack.packb(cmd_data)
         ])
         img_bytes = self.zmq_socket.recv()
-        return img_bytes
         img = Image.open(io.BytesIO(img_bytes))
         return img
 


### PR DESCRIPTION
This PR follows https://github.com/rdeits/meshcat/pull/85.

It adds a new `get_image()` method to `meshcat.Visualizer`. This relies on the new `capture_image` command added in rdeits/meshcat#85 which queries an image returned to the Meshcat client as a PNG in base64 data URI form.

## Design

On the Python side, the WebsocketHandler awaits the response from the Meshcat client, and when it receives the JSON from the frontend, the `on_message()` callback is triggered, which sends the PNG (turned into a sequence of bytes) over the ZMQ bridge.


## Limitations

The design is not completely robust yet. It requires the browser window be already open to get a response in the client (the visualizer will block until then).  
Maybe this behavior can be fixed by using something else to get the PNG render.