### PR TITLE
Fix mp4 unplayable on Mac

### DIFF
--- a/src/meshcat/animation.py
+++ b/src/meshcat/animation.py
@@ -147,6 +147,7 @@ def convert_frames_to_video(tar_file_path, output_path="output.mp4", framerate=6
                 "-i", r"%07d.png",
                 "-vcodec", "libx264",
                 "-preset", "slow",
+                "-pix_fmt", "yuv420p",
                 "-crf", "18"]
         if overwrite:
             args.append("-y")
@@ -158,7 +159,7 @@ def convert_frames_to_video(tar_file_path, output_path="output.mp4", framerate=6
 Could not call `ffmpeg` to convert your frames into a video.
 If you want to convert the frames manually, you can extract the
 .tar archive into a directory, cd to that directory, and run:
-ffmpeg -r 60 -i %07d.png \\\n\t -vcodec libx264 \\\n\t -preset slow \\\n\t -crf 18 \\\n\t output.mp4
+ffmpeg -r 60 -i %07d.png -vcodec libx264 -preset slow -pix_fmt yuv420p -crf 18 output.mp4
                 """)
             raise
     print("Saved output as {:s}".format(output_path))


### PR DESCRIPTION
The issue: The `output.mp4` saved by `convert_frames_to_video` isn't playable by QuickTime player on Mac (@TobiaMarcucci had issues playing it with many other apps on Mac too).

The fix: Based on https://apple.stackexchange.com/questions/166553/why-wont-video-from-ffmpeg-show-in-quicktime-imovie-or-quick-preview, pixel format incompatibility is the culprit, hence the simple fix. (apparently @DannyDriess had suggested this very fix in our discussion thread and I missed it; sorry Danny.)

Also, https://stackoverflow.com/questions/46164041/default-pixel-format-for-ffmpeg-for-encoding-an-image-stack-to-movie suggests that `ffmpeg` isn't particularly picky about the `-pix_fmt` flag as its default behavior is on a case-by-case basis and platform-agnostic anyway. So I felt comfortable enough hardcoding the `yuv420p` option. But feel free to let me know if you'd prefer it being an argument. 