### PR TITLE
[rebased] Text rendering: python-side 

### DIFF
--- a/examples/demo.ipynb
+++ b/examples/demo.ipynb
@@ -157,6 +157,75 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "MeshCat supports simple 2d texts rendering. For example, to write 2d texts onto a geometry:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vis.set_object(g.Box([1, 1, 2]),g.MeshPhongMaterial(map=g.TextTexture('Hello, world!')))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is also possible to simple write 'floating' texts onto a scene without attaching it to an object (e.g., for scene description):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vis.delete()\n",
+    "vis.set_object(g.SceneText('Hello, world!',font_size=100))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "and just like the usual geometry/object, the scene texts can be rotated:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Rz = tf.rotation_matrix(np.pi/2, [0, 0, 1])\n",
+    "Ry = tf.rotation_matrix(np.pi/2, [0, 1, 0])\n",
+    "vis.set_transform(Ry.dot(Rz))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Under the hood, the `SceneTexts` are written onto a `Plane` geometry, and the plane size can be specified by width and height. These two parameters affect the texts size when the font_size itself is set too large; they would force a font downsizing when rendering so as to fit all the texts within the specified plane."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in np.linspace(8,2,10):\n",
+    "    vis.set_object(g.SceneText('Hello, world!',width=2*i,height=2*i,font_size=300))\n",
+    "    time.sleep(0.05)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## The Scene Tree\n",
     "\n",
     "Obviously, we will often want to draw more than one object. So how do we do that? The fundamental idea of MeshCat is that it gives direct access to the *scene graph*. You can think of the scene as a tree of objects, and we name each object in the tree by its *path* from the root of the tree. Children in the tree inherit the transformations applied to their parents. So, for example, we might have a `robot` at the path `/robot`, and that robot might have a child called `head` at the path `/robot/head`. Each path in the tree can have a different geometry associated.\n",

--- a/src/meshcat/commands.py
+++ b/src/meshcat/commands.py
@@ -1,4 +1,4 @@
-from .geometry import Geometry, Object, Mesh, MeshPhongMaterial, OrthographicCamera, PerspectiveCamera, PointsMaterial, Points
+from .geometry import Geometry, Object, Mesh, MeshPhongMaterial, OrthographicCamera, PerspectiveCamera, PointsMaterial, Points, TextTexture
 from .path import Path
 
 

--- a/src/meshcat/geometry.py
+++ b/src/meshcat/geometry.py
@@ -216,8 +216,7 @@ class PngImage(Image):
 
 
 class TextTexture(Texture):
-    def __init__(self, text, font_size=100, font_face='sans-serif',
-                 width=200, height=100, position=[10, 10]):
+    def __init__(self, text, font_size=100, font_face='sans-serif'):
         super(TextTexture, self).__init__()
         self.text = text
         # font_size will be passed to the JS side as is; however if the

--- a/src/meshcat/geometry.py
+++ b/src/meshcat/geometry.py
@@ -80,6 +80,26 @@ class Ellipsoid(Sphere):
         return np.diag(np.hstack((self.radii, 1.0)))
 
 
+class Plane(Geometry):
+
+    def __init__(self, width=1, height=1, widthSegments=1, heightSegments=1):
+        super(Plane, self).__init__()
+        self.width = width
+        self.height = height
+        self.widthSegments = widthSegments
+        self.heightSegments = heightSegments
+
+    def lower(self, object_data):
+        return {
+            u"uuid": self.uuid,
+            u"type": u"PlaneGeometry",
+            u"width": self.width,
+            u"height": self.height,
+            u"widthSegments": self.widthSegments,
+            u"heightSegments": self.heightSegments,
+        }
+
+
 """
 A cylinder of the given height and radius. By Three.js convention, the axis of
 rotational symmetry is aligned with the y-axis.
@@ -192,6 +212,26 @@ class PngImage(Image):
         return {
             u"uuid": self.uuid,
             u"url": str("data:image/png;base64," + base64.b64encode(self.data).decode('ascii'))
+        }
+
+
+class TextTexture(Texture):
+    def __init__(self, text, font_size=100, font_face='sans-serif',
+                 width=200, height=100, position=[10, 10]):
+        super(TextTexture, self).__init__()
+        self.text = text
+        # font_size will be passed to the JS side as is; however if the
+        # text width exceeds canvas width, font_size will be reduced.
+        self.font_size = font_size
+        self.font_face = font_face
+
+    def lower(self, object_data):
+        return {
+            u"uuid": self.uuid,
+            u"type": u"_text",
+            u"text": unicode(self.text),
+            u"font_size": self.font_size,
+            u"font_face": self.font_face,
         }
 
 
@@ -550,6 +590,13 @@ def PointCloud(position, color, **kwargs):
         PointsMaterial(**kwargs)
     )
 
+
+def SceneText(text, width=10, height=10, **kwargs):
+    return Mesh(
+        Plane(width=width,height=height),
+        MeshPhongMaterial(map=TextTexture(text,**kwargs),transparent=True,
+            needsUpdate=True)
+        )
 
 class Line(Object):
     _type = u"Line"

--- a/src/meshcat/geometry.py
+++ b/src/meshcat/geometry.py
@@ -229,7 +229,7 @@ class TextTexture(Texture):
         return {
             u"uuid": self.uuid,
             u"type": u"_text",
-            u"text": unicode(self.text),
+            u"text": self.text,
             u"font_size": self.font_size,
             u"font_face": self.font_face,
         }


### PR DESCRIPTION
I do not claim any credit for this work, I merely squashed & rebased @shensquared's work in https://github.com/rdeits/meshcat-python/pull/32. The only "intelligent" change I had to do is remove a use of `unicode` since we're python3 now.

I tested the relevant `demo.ipynb` and was able to reproduce the results. Here's the state after the final cell is run:

![image](https://user-images.githubusercontent.com/19834684/154037930-96538466-8e4b-4fae-b7b4-ff36e6148c99.png)

I hope this will save you some work, and help merge this nice feature to `meshcat` :)


