### PR TITLE
UUID caching

### DIFF
--- a/src/meshcat/geometry.py
+++ b/src/meshcat/geometry.py
@@ -268,6 +268,9 @@ class ImageTexture(Texture):
 
 
 class Object(SceneElement):
+    sent_geom_uuids = set()
+    sent_material_uuids = set()
+
     def __init__(self, geometry, material=MeshPhongMaterial()):
         super(Object, self).__init__()
         self.geometry = geometry
@@ -289,8 +292,15 @@ class Object(SceneElement):
                 u"matrix": list(self.geometry.intrinsic_transform().flatten())
             }
         }
-        self.geometry.lower_in_object(data)
-        self.material.lower_in_object(data)
+        # If this geometry or material has been previously sent,
+        # then we don't need to populate these fields; the server
+        # will load the matching geometry or material from its cache.
+        if self.geometry.uuid not in self.sent_geom_uuids:
+            self.sent_geom_uuids.add(self.geometry.uuid)
+            self.geometry.lower_in_object(data)
+        if self.material.uuid not in self.sent_material_uuids:
+            self.sent_material_uuids.add(self.material.uuid)
+            self.material.lower_in_object(data)
         return data
 
 

--- a/src/meshcat/tests/test_drawing.py
+++ b/src/meshcat/tests/test_drawing.py
@@ -23,10 +23,10 @@ class VisualizerTest(unittest.TestCase):
             port = self.vis.url().split(":")[-1].split("/")[0]
             self.dummy_proc = subprocess.Popen([sys.executable, "-m", "meshcat.tests.dummy_websocket_client", str(port)])
         else:
-            #self.vis.open()
+            self.vis.open()
             self.dummy_proc = None
 
-        #self.vis.wait()
+        self.vis.wait()
 
     def tearDown(self):
         if self.dummy_proc is not None:
@@ -304,9 +304,6 @@ class TestUUIDCloning(VisualizerTest):
         v2 = v["duplicate"]
         v2.set_transform(tf.translation_matrix([2., 0., 0.]))
         v2.set_object(geom_2, mat_2)
-
-        import time
-        time.sleep(1000)
         
 class TestOrthographicCamera(VisualizerTest):
     def runTest(self):

--- a/src/meshcat/tests/test_drawing.py
+++ b/src/meshcat/tests/test_drawing.py
@@ -23,10 +23,10 @@ class VisualizerTest(unittest.TestCase):
             port = self.vis.url().split(":")[-1].split("/")[0]
             self.dummy_proc = subprocess.Popen([sys.executable, "-m", "meshcat.tests.dummy_websocket_client", str(port)])
         else:
-            self.vis.open()
+            #self.vis.open()
             self.dummy_proc = None
 
-        self.vis.wait()
+        #self.vis.wait()
 
     def tearDown(self):
         if self.dummy_proc is not None:
@@ -271,6 +271,43 @@ class TestTriangularMesh(VisualizerTest):
         v.set_object(g.TriangularMeshGeometry(vertices, faces, colors), g.MeshLambertMaterial(vertexColors=True, wireframe=True))
 
 
+class TestUUIDCloning(VisualizerTest):
+    def runTest(self):
+        """
+        Test that geometry with identical UUIDs are handled correctly.
+        """
+        v = self.vis["triangular_mesh"]
+        v.set_transform(tf.rotation_matrix(np.pi/2, [0., 0, 1]))
+        vertices = np.array([
+            [0, 0, 0],
+            [1, 0, 0],
+            [1, 0, 1],
+            [0, 0, 1]
+        ])
+        faces = np.array([
+            [0, 1, 2],
+            [3, 0, 2]
+        ])
+        geom = g.TriangularMeshGeometry(vertices, faces)
+        mat = g.MeshLambertMaterial(color=0xeedd22, wireframe=True)
+        geom.uuid = 1234
+        mat.uuid = 5678
+        v.set_object(geom, mat)
+
+        # This should be drawn as a duplicate of the first geometry
+        # at and offset; if nothing appears, or the material is different,
+        # the UUID lookup did not succeed.
+        geom_2 = g.TriangularMeshGeometry(np.empty((0, 3)), np.empty((0, 3)))
+        mat_2 = g.MeshLambertMaterial(color=0x000000, wireframe=False)
+        geom_2.uuid = 1234
+        mat_2.uuid = 5678
+        v2 = v["duplicate"]
+        v2.set_transform(tf.translation_matrix([2., 0., 0.]))
+        v2.set_object(geom_2, mat_2)
+
+        import time
+        time.sleep(1000)
+        
 class TestOrthographicCamera(VisualizerTest):
     def runTest(self):
         """


### PR DESCRIPTION
This pairs with PR [edit this in] to avoid re-sending geometry or materials with duplicate UUIDs while achieving the same visualization result.

This hopefully saves a ton of bandwidth, and also dramatically reduces static_html export size for scenes with many repeated heavy elements. For example, the attached scene serializes to ~1MB with this caching, but >100MB without.

[save_with_caching.zip](https://github.com/rdeits/meshcat-python/files/8526235/save_with_caching.zip)

