### PR TITLE
Fix continuous integration matrix

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -12,8 +12,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         os: [ubuntu-latest, windows-latest]
+        include:
+            - os: ubuntu-20.04
+              python-version: 3.6
+            - os: windows-latest
+              python-version: 3.6
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-latest, windows-latest]
         include:
             - os: ubuntu-20.04


### PR DESCRIPTION
Python 3.6 is not available in ubuntu-latest (22.04).

This PR merely changes ``(ubuntu-latest, python-3.6)`` to ``(ubuntu-20.04, python-3.6)`` in the matrix strategy.