### PR TITLE
CI: update Codecov to v3

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -42,6 +42,6 @@ jobs:
       run: |
         pytest --cov=./
     - name: "Upload coverage to Codecov"
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true


### PR DESCRIPTION
As of February 1, 2022, v1 [has been fully sunset](https://github.com/codecov/codecov-action#readme) and no longer functions. This is likely the cause of the [error we see in windows-latest jobs](https://github.com/rdeits/meshcat-python/actions/runs/3983333631/jobs/6828572853):

    {'detail': ErrorDetail(string='Missing "owner" argument. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}

This PR updates to Codecov v3.