### PR TITLE
Allow foreign origin websocket connections

### DIFF
--- a/src/meshcat/servers/zmqserver.py
+++ b/src/meshcat/servers/zmqserver.py
@@ -123,6 +123,9 @@ class WebSocketHandler(tornado.websocket.WebSocketHandler):
         self.bridge = kwargs.pop("bridge")
         super(WebSocketHandler, self).__init__(*args, **kwargs)
 
+    def check_origin(self, origin):
+        return True
+
     def open(self):
         self.bridge.websocket_pool.add(self)
         print("opened:", self, file=sys.stderr)


### PR DESCRIPTION
When using the Javascript-Viewer in a static website, I got 403 http-error when connecting to the websocket of `meshcat-server`. This PR disables the rejection of foreign origin requests as proposed [here](https://stackoverflow.com/a/25071488/10429267).