### PR TITLE
Add billboard capability

### DIFF
--- a/src/meshcat/geometry.py
+++ b/src/meshcat/geometry.py
@@ -295,19 +295,23 @@ class Object(SceneElement):
 
 
 class BillboardObject(Object):
-    def __init__(self, text, base_width, size, global_scale=1):
+    def __init__(self, text, base_width, size, global_scale=1, text_color='white', background_color='blue'):
         """
 
         :param text: Text to put on the billboard
         :param base_width: Width of the billboard in pixels
         :param size: Height of the text in pixels
         :param global_scale: Scale factor to apply to the billboard (0.01 gets it to roughly meter size)
+        :param text_color: Color name for the text
+        :param background_color: Color name for the background
         """
         super(BillboardObject, self).__init__([])
         self.text = text
         self.base_width = base_width
         self.size = size
         self.global_scale = global_scale
+        self.text_color = text_color
+        self.background_color = background_color
 
     def lower(self):
         return {
@@ -324,7 +328,9 @@ class BillboardObject(Object):
                 u"base_width": self.base_width,
                 u"size": self.size,
                 u"global_scale": self.global_scale,
-                u"matrix": np.eye(4).flatten().tolist()
+                u"matrix": np.eye(4).flatten().tolist(),
+                u"text_color": self.text_color,
+                u"background_color": self.background_color,
             }
         }
 

--- a/src/meshcat/geometry.py
+++ b/src/meshcat/geometry.py
@@ -294,6 +294,41 @@ class Object(SceneElement):
         return data
 
 
+class BillboardObject(Object):
+    def __init__(self, text, base_width, size, global_scale=1):
+        """
+
+        :param text: Text to put on the billboard
+        :param base_width: Width of the billboard in pixels
+        :param size: Height of the text in pixels
+        :param global_scale: Scale factor to apply to the billboard (0.01 gets it to roughly meter size)
+        """
+        super(BillboardObject, self).__init__([])
+        self.text = text
+        self.base_width = base_width
+        self.size = size
+        self.global_scale = global_scale
+
+    def lower(self):
+        return {
+            u"metadata": {
+                u"version": 4.5,
+                u"type": u"_billboard",
+            },
+            u"geometries": [],
+            u"materials": [],
+            u"object": {
+                u"uuid": self.uuid,
+                u"type": u"_billboard",
+                u"text": self.text,
+                u"base_width": self.base_width,
+                u"size": self.size,
+                u"global_scale": self.global_scale,
+                u"matrix": np.eye(4).flatten().tolist()
+            }
+        }
+
+
 class Mesh(Object):
     _type = u"Mesh"
 

--- a/src/meshcat/visualizer.py
+++ b/src/meshcat/visualizer.py
@@ -84,7 +84,7 @@ class ViewerWindow:
         self.zmq_socket.close()
         self.context.destroy()
         if self.server_proc is not None:
-            self.server_proc.send_signal(signal.SIGINT)
+            self.server_proc.kill()
             self.server_proc.wait()
 
 def srcdoc_escape(x):

--- a/src/meshcat/visualizer.py
+++ b/src/meshcat/visualizer.py
@@ -1,3 +1,4 @@
+import signal
 import webbrowser
 import umsgpack
 import numpy as np
@@ -79,6 +80,12 @@ class ViewerWindow:
         img = Image.open(io.BytesIO(img_bytes))
         return img
 
+    def close(self):
+        self.zmq_socket.close()
+        self.context.destroy()
+        if self.server_proc is not None:
+            self.server_proc.send_signal(signal.SIGINT)
+            self.server_proc.wait()
 
 def srcdoc_escape(x):
     return x.replace("&", "&amp;").replace('"', "&quot;")


### PR DESCRIPTION
Add sprite drawing as a way to add billboards (2D text annotations that always face the camera). Allows to write text unto the scene.

The underlying changes to meshcat are proposed in this PR: https://github.com/rdeits/meshcat/pull/145

An example:

![Screenshot from 2023-07-03 14-26-30](https://github.com/rdeits/meshcat-python/assets/22916306/4fefaa47-cd86-4aaf-88d0-869711d1372e)

Code to recreate the screenshot:

```
import meshcat
import numpy as np
t = meshcat.geometry.BillboardObject("test444", 75, 16, 0.01, "green", "red")

# !pip install timor-python
from timor.utilities import prebuilt_robots  
r = prebuilt_robots.get_six_axis_assembly()
viz = r.robot.visualize()

viz.viewer["test"].set_object(t)
viz.viewer["test"].set_transform(np.asarray(((1, 0., 0., 1.), (0, 1, 0, 1),(0, 0, 1, 0),(0, 0, 0, 1.))))

# Alternative w/out robot
viz = meshcat.Visualizer()
viz.initViewer()
viz["test"].set_object(t)
viz["test"].set_transform(np.asarray(((1, 0., 0., 1.), (0, 1, 0, 1),(0, 0, 1, 0),(0, 0, 0, 1.))))
```

