### PR TITLE
three.js new lighting and color management - add colorspace to ImageTexture

### DIFF
--- a/src/meshcat/geometry.py
+++ b/src/meshcat/geometry.py
@@ -261,7 +261,8 @@ class ImageTexture(Texture):
             u"uuid": self.uuid,
             u"wrap": self.wrap,
             u"repeat": self.repeat,
-            u"image": self.image.lower_in_object(object_data)
+            u"image": self.image.lower_in_object(object_data),
+            u"colorSpace": "srgb"
         }
         data.update(self.properties)
         return data


### PR DESCRIPTION
For the transition to the new lighting-model in three.js there were a [few updates](https://github.com/meshcat-dev/meshcat/pull/155) made to meshcat.

To render obj-files with textures correctly in this new version, the textures need to have the `colorSpace` attribute set accordingly (see discussion [here](https://discourse.threejs.org/t/transitioning-to-an-srgb-workflow/62623/2)). This MR adds the parameter to the json.