### PR TITLE
commands.py: do not set "property" to lowercase

### DIFF
--- a/src/meshcat/commands.py
+++ b/src/meshcat/commands.py
@@ -98,7 +98,7 @@ class SetProperty:
         return {
             u"type": u"set_property",
             u"path": self.path.lower(),
-            u"property": self.key.lower(),
+            u"property": self.key,
             u"value": self.value
         }
 


### PR DESCRIPTION
+ fixes setting camelCase properties such as "castShadow" on Three.js lights