### PR TITLE
Update Readme.rst to install latest version using pip

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -35,10 +35,7 @@ From source:
 
 ::
 
-    git clone https://github.com/meshcat-dev/meshcat-python
-    git submodule update --init --recursive
-    cd meshcat-python
-    python setup.py install
+    pip install git+https://github.com/meshcat-dev/meshcat-python.git
 
 You will need the ZeroMQ libraries installed on your system:
 


### PR DESCRIPTION
The old install method is complex and has issue, install using pip from source is much simple and robust. You even dont need to install ZeroMQ to use it.